### PR TITLE
add cli option for gRPC max message size

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,10 +10,11 @@ import (
 type CLI struct {
 	Debug bool `short:"d" help:"Emit debug logs in addition to info logs."`
 
-	Network     string `help:"Network on which to listen for gRPC connections." default:"tcp"`
-	Address     string `help:"Address at which to listen for gRPC connections." default:":9443"`
-	TLSCertsDir string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
-	Insecure    bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
+	Network            string `help:"Network on which to listen for gRPC connections." default:"tcp"`
+	Address            string `help:"Address at which to listen for gRPC connections." default:":9443"`
+	TLSCertsDir        string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
+	Insecure           bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
+	MaxRecvMessageSize int    `help:"Maximum size of received messages in MB." default:"4"`
 }
 
 // Run this Function.
@@ -26,7 +27,9 @@ func (c *CLI) Run() error {
 	return function.Serve(&Function{log: log},
 		function.Listen(c.Network, c.Address),
 		function.MTLSCertificates(c.TLSCertsDir),
-		function.Insecure(c.Insecure))
+		function.Insecure(c.Insecure),
+		function.MaxRecvMessageSize(c.MaxRecvMessageSize*1024*1024))
+
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ func (c *CLI) Run() error {
 		function.MTLSCertificates(c.TLSCertsDir),
 		function.Insecure(c.Insecure),
 		function.MaxRecvMessageSize(c.MaxRecvMessageSize*1024*1024))
-
 }
 
 func main() {


### PR DESCRIPTION
### Description of your changes

Adds a cli option, `--max-recv-message-size` to allow users to set the gRPC max message size. 

Fixes # https://github.com/crossplane/crossplane/issues/6392

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
